### PR TITLE
Added the Python Example for the Delete Results API

### DIFF
--- a/Python Examples/ReadMe.md
+++ b/Python Examples/ReadMe.md
@@ -30,3 +30,4 @@ API Examples
 ### [Test Monitor](TestMonitor)
 
 - [CreateResultsAndSteps](TestMonitor/CreateResultsAndSteps/create_results_and_steps.py): Demonstrates how to use the SystemLink Test Monitor API to publish test results to the server.
+- [DeleteResults](TestMonitor/DeleteResults/delete_results.py): Demonstrates how to use the SystemLink Test Monitor API to create and delete test results.

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -2,7 +2,7 @@ Test Monitor Delete Results Example
 =================
 
 This is an python example demonstrating how to use the
-SystemLink Enterprise Test Monitor API to create test results and steps.
+SystemLink Enterprise Test Monitor API to create and delete test results.
 
 Running the Example
 -------------------

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -13,10 +13,10 @@ Running the Example
 To run the example, use the following command:
 
 ```
-python <filename.py> <server_url> <api_key>
+python <filename.py> --server <server_url> <api_key>
 ```
 
-For example: `python Delete_Results.py https://my_server apiKey`.
+For example: `python delete_results.py --server https://my_server apiKey`.
 
 How to generate API key
 -----------------------

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -1,8 +1,8 @@
-Test Monitor Results Example
+Test Monitor Delete Results Example
 =================
 
 This is an python example demonstrating how to use the
-SystemLink Test Monitor API to create test results and steps.
+SystemLink Enterprise Test Monitor API to create test results and steps.
 
 Running the Example
 -------------------
@@ -17,6 +17,10 @@ python <filename.py> <url> <api_key>
 ```
 
 For example: `python Delete_Results.py https://my_server apiKey`.
+
+How to generate API key
+-----------------------
+Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key
 
 About the Example
 -----------------

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -1,0 +1,24 @@
+Test Monitor Results Example
+=================
+
+This is an python example demonstrating how to use the
+SystemLink Test Monitor API to create test results and steps.
+
+Running the Example
+-------------------
+
+1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
+2. Install the [Python SDK](https://www.python.org/downloads/).
+
+To run the example, use the following command:
+
+```
+python <filename.py> <url> <api_key>
+```
+
+For example: `python Delete_Results.py https://my_server apiKey`.
+
+About the Example
+-----------------
+
+This example creates a single test result and deletes this created result by using Delete result Api and creates multiple(five) test results and deletes all these multiple results at a time by using delete-results POST Api.

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -13,7 +13,7 @@ Running the Example
 To run the example, use the following command:
 
 ```
-python <filename.py> <url> <api_key>
+python <filename.py> <server_url> <api_key>
 ```
 
 For example: `python Delete_Results.py https://my_server apiKey`.

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -11,6 +11,8 @@ import uuid
 import sys
 import os
 import datetime
+from typing import Any, Tuple, Dict, List
+import click
 
 current = os.path.dirname(os.path.realpath(__file__))
 parent = os.path.dirname(current)
@@ -18,12 +20,12 @@ sys.path.append(parent)
 
 import test_data_manager_client
 
-def get_test_result():
+def get_test_result() -> Dict:
     test_result = {
         "programName": "Power Test",
         "status": {
-            "statusType": "PASSED",
-            "statusName": "Passed"
+            "statusType": "RUNNING",
+            "statusName": "Running"
         },
         "systemId": None,
         "hostName": None,
@@ -32,13 +34,13 @@ def get_test_result():
         "operator": "John Smith",
         "partNumber": "NI-ABC-123-PWR1",
         "fileIds":None,
-        "startedAt": str(datetime.datetime.now()),
-        "totalTimeInSeconds": 13.6
+        "startedAt": str(datetime.datetime.utcnow()),
+        "totalTimeInSeconds": 0.0
     }
 
     return test_result
 
-def create_multiple_results(result_ids, test_result):
+def create_multiple_results(result_ids: List, test_result: Dict):
     for i in range(0,5):
         test_result['programName'] = test_result['programName'] + str(i)
         response = test_data_manager_client.create_results(results=[test_result])
@@ -48,8 +50,21 @@ def create_multiple_results(result_ids, test_result):
 
     return result_ids
 
-def main():
 
+@click.command()
+@click.option("--server", help = "Enter server url")
+@click.argument("api_key")
+def main(server, api_key):
+    """
+    To run the example against a SystemLink Enterprise, the URL should include
+    the scheme, host, and port if not default.\n
+    For example:\n
+    python create_results_and_steps.py --server https://myserver:9091 api_key.\n
+
+    For more information on how to generate API key, please refer to the documentation provided.
+    """
+    test_data_manager_client.set_base_url_and_api_key(server, api_key)
+    
     try:
 
         test_result = get_test_result()
@@ -84,7 +99,7 @@ def main():
         print(e)
         print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the server is up and the URL or API key is valid")
         print("For more information on how to generate API key, please refer to the documentation provided.")
-
+        print("Try 'create_results_and_steps.py --help' for help.")
 
 if __name__ == "__main__":
     main()

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -1,3 +1,12 @@
+"""
+SystemLink Enterprise TestMonitor delete results example
+
+This example creates a single test result and 
+deletes this created result by using Delete result Api and 
+creates multiple(five) test results and 
+deletes all these multiple results at a time by using delete-results Api.
+"""
+
 import uuid
 import sys
 import os

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -11,7 +11,7 @@ import uuid
 import sys
 import os
 import datetime
-from typing import Any, Tuple, Dict, List
+from typing import Dict, List
 import click
 
 current = os.path.dirname(os.path.realpath(__file__))

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -39,7 +39,7 @@ def main():
         input()
 
         # delete test result
-        request_response = test_data_manager_client.delete_result(test_result['id'], True)
+        test_data_manager_client.delete_result(test_result['id'], True)
         print(f"\nThe test result with Id = {test_result['id']} has been deleted")
         
         # create multiple test results
@@ -57,7 +57,7 @@ def main():
         input()
 
         # Delete multiple test results
-        request_response = test_data_manager_client.delete_results(result_ids, True)
+        test_data_manager_client.delete_results(result_ids, True)
         print("\nResults has been deleted successfully")
         
     except Exception as e:

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -1,0 +1,63 @@
+import uuid
+import sys
+import os
+import datetime
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+import test_data_manager_client
+
+def main():
+
+    test_result = {
+        "programName": "Power Test",
+        "status": {
+        "statusType": "RUNNING",
+        "statusName": "Running"
+        },
+        "systemId": None,
+        "hostName": None,
+        "properties":None,
+        "serialNumber": str(uuid.uuid4()),
+        "operator": "John Smith",
+        "partNumber": "NI-ABC-123-PWR1",
+        "fileIds":None,
+        "startedAt": str(datetime.datetime.now()),
+        "totalTimeInSeconds": 0.0
+    }
+
+    # create test result
+    response = test_data_manager_client.create_results(results=[test_result])
+    test_result = response["results"][0]
+    
+    print(f"The test result has been under part number={test_result['partNumber']} with Id = {test_result['id']}")
+    print("Press enter to delete the result")
+    input()
+
+    # delete test result
+    request_response = test_data_manager_client.delete_result(test_result['id'], True)
+    print(f"\nThe test result with Id = {test_result['id']} has been deleted")
+    
+    # create multiple test results
+    print("\nCreating multiple test results.\nResult Ids has been listed down below")
+    result_ids = []
+    for i in range(0,5):
+        test_result['programName'] = test_result['programName'] + str(i)
+        response = test_data_manager_client.create_results(results=[test_result])
+        test_result = response["results"][0]
+        result_ids.append(test_result["id"])
+        print(f"{test_result['id']}")
+    
+    print("\nThe multiple results has been created successfully")
+    print("Please any key to delete these results")
+    input()
+
+    # Delete multiple test results
+    request_response = test_data_manager_client.delete_results(result_ids, True)
+    print("\nResults has been deleted successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -9,26 +9,41 @@ sys.path.append(parent)
 
 import test_data_manager_client
 
+def get_test_result():
+    test_result = {
+        "programName": "Power Test",
+        "status": {
+            "statusType": "RUNNING",
+            "statusName": "Running"
+        },
+        "systemId": None,
+        "hostName": None,
+        "properties":None,
+        "serialNumber": str(uuid.uuid4()),
+        "operator": "John Smith",
+        "partNumber": "NI-ABC-123-PWR1",
+        "fileIds":None,
+        "startedAt": str(datetime.datetime.now()),
+        "totalTimeInSeconds": 0.0
+    }
+
+    return test_result
+
+def create_multiple_results(result_ids, test_result):
+    for i in range(0,5):
+        test_result['programName'] = test_result['programName'] + str(i)
+        response = test_data_manager_client.create_results(results=[test_result])
+        test_result = response["results"][0]
+        result_ids.append(test_result["id"])
+        print(f"{test_result['id']}")
+
+    return result_ids
+
 def main():
 
     try:
 
-        test_result = {
-            "programName": "Power Test",
-            "status": {
-            "statusType": "RUNNING",
-            "statusName": "Running"
-            },
-            "systemId": None,
-            "hostName": None,
-            "properties":None,
-            "serialNumber": str(uuid.uuid4()),
-            "operator": "John Smith",
-            "partNumber": "NI-ABC-123-PWR1",
-            "fileIds":None,
-            "startedAt": str(datetime.datetime.now()),
-            "totalTimeInSeconds": 0.0
-        }
+        test_result = get_test_result()
 
         # create test result
         response = test_data_manager_client.create_results(results=[test_result])
@@ -45,12 +60,8 @@ def main():
         # create multiple test results
         print("\nCreating multiple test results.\nResult Ids has been listed down below")
         result_ids = []
-        for i in range(0,5):
-            test_result['programName'] = test_result['programName'] + str(i)
-            response = test_data_manager_client.create_results(results=[test_result])
-            test_result = response["results"][0]
-            result_ids.append(test_result["id"])
-            print(f"{test_result['id']}")
+        
+        result_ids = create_multiple_results(result_ids, test_result)
         
         print("\nThe multiple results has been created successfully")
         print("Please enter to delete these results")

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -11,52 +11,59 @@ import test_data_manager_client
 
 def main():
 
-    test_result = {
-        "programName": "Power Test",
-        "status": {
-        "statusType": "RUNNING",
-        "statusName": "Running"
-        },
-        "systemId": None,
-        "hostName": None,
-        "properties":None,
-        "serialNumber": str(uuid.uuid4()),
-        "operator": "John Smith",
-        "partNumber": "NI-ABC-123-PWR1",
-        "fileIds":None,
-        "startedAt": str(datetime.datetime.now()),
-        "totalTimeInSeconds": 0.0
-    }
+    try:
 
-    # create test result
-    response = test_data_manager_client.create_results(results=[test_result])
-    test_result = response["results"][0]
-    
-    print(f"The test result has been under part number={test_result['partNumber']} with Id = {test_result['id']}")
-    print("Press enter to delete the result")
-    input()
+        test_result = {
+            "programName": "Power Test",
+            "status": {
+            "statusType": "RUNNING",
+            "statusName": "Running"
+            },
+            "systemId": None,
+            "hostName": None,
+            "properties":None,
+            "serialNumber": str(uuid.uuid4()),
+            "operator": "John Smith",
+            "partNumber": "NI-ABC-123-PWR1",
+            "fileIds":None,
+            "startedAt": str(datetime.datetime.now()),
+            "totalTimeInSeconds": 0.0
+        }
 
-    # delete test result
-    request_response = test_data_manager_client.delete_result(test_result['id'], True)
-    print(f"\nThe test result with Id = {test_result['id']} has been deleted")
-    
-    # create multiple test results
-    print("\nCreating multiple test results.\nResult Ids has been listed down below")
-    result_ids = []
-    for i in range(0,5):
-        test_result['programName'] = test_result['programName'] + str(i)
+        # create test result
         response = test_data_manager_client.create_results(results=[test_result])
         test_result = response["results"][0]
-        result_ids.append(test_result["id"])
-        print(f"{test_result['id']}")
-    
-    print("\nThe multiple results has been created successfully")
-    print("Please any key to delete these results")
-    input()
+        
+        print(f"The test result has been under part number={test_result['partNumber']} with Id = {test_result['id']}")
+        print("Press enter to delete the result")
+        input()
 
-    # Delete multiple test results
-    request_response = test_data_manager_client.delete_results(result_ids, True)
-    print("\nResults has been deleted successfully")
+        # delete test result
+        request_response = test_data_manager_client.delete_result(test_result['id'], True)
+        print(f"\nThe test result with Id = {test_result['id']} has been deleted")
+        
+        # create multiple test results
+        print("\nCreating multiple test results.\nResult Ids has been listed down below")
+        result_ids = []
+        for i in range(0,5):
+            test_result['programName'] = test_result['programName'] + str(i)
+            response = test_data_manager_client.create_results(results=[test_result])
+            test_result = response["results"][0]
+            result_ids.append(test_result["id"])
+            print(f"{test_result['id']}")
+        
+        print("\nThe multiple results has been created successfully")
+        print("Please enter to delete these results")
+        input()
+
+        # Delete multiple test results
+        request_response = test_data_manager_client.delete_results(result_ids, True)
+        print("\nResults has been deleted successfully")
+        
+    except Exception as e:
+        print(e)
+        print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the server is up and the URL or API key is valid")
+        print("For more information on how to generate API key, please refer to the documentation provided.")
 
 
 if __name__ == "__main__":

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -2,9 +2,9 @@
 SystemLink Enterprise TestMonitor delete results example
 
 This example creates a single test result and 
-deletes this created result by using Delete result Api and 
+deletes this created result by using delete result API and 
 creates multiple(five) test results and 
-deletes all these multiple results at a time by using delete-results Api.
+deletes all these multiple results at once by using delete-results API.
 """
 
 import uuid
@@ -40,16 +40,81 @@ def get_test_result() -> Dict:
 
     return test_result
 
-def create_multiple_results(result_ids: List, test_result: Dict):
+
+def is_partial_success_response(response: Dict) -> bool:
+    return "error" in response.keys()
+
+
+def create_single_result() -> Dict:
+    test_result = get_test_result()
+
+    # create test result
+    response = test_data_manager_client.create_results(results=[test_result])
+    if is_partial_success_response(response):
+        raise Exception("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+    test_result = response["results"][0]
+
+    return test_result
+
+
+def delete_single_result(result_id: str) -> None:
+    try:
+        test_data_manager_client.delete_result(result_id, True)
+        print(f"\nThe test result with Id = {result_id} has been deleted")
+    except:
+        print("Error occurred while deleting the test result, please check for the correct result Id and you have correct access for deleting the results")
+
+
+def create_and_delete_single_result() -> None:
+    
+    # create test result
+    print("Creating New test result")
+    test_result = create_single_result()    
+    print(f"Test result has been created under part number={test_result['partNumber']} with Id = {test_result['id']}")
+    
+    # delete test result
+    print("Press enter to delete the result")
+    input()
+    delete_single_result(test_result["id"])
+
+
+def create_multiple_results() -> List:
+    test_result = get_test_result()
+    result_ids = []
     for i in range(0,5):
         test_result['programName'] = test_result['programName'] + str(i)
         response = test_data_manager_client.create_results(results=[test_result])
-        test_result = response["results"][0]
-        result_ids.append(test_result["id"])
-        print(f"{test_result['id']}")
+        if is_partial_success_response(response):
+            print("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+        else:
+            test_result = response["results"][0]
+            result_ids.append(test_result["id"])
+            print(f"{test_result['id']}")
+    if len(result_ids) > 0 :
+        return result_ids
+    else:
+        raise Exception("Error occurred while creating multiple new test results, please check whether you have correct access for creating the new test results")
 
-    return result_ids
 
+def delete_multiple_results(result_ids: List) -> None:
+    response = test_data_manager_client.delete_results(result_ids, True)
+    if is_partial_success_response(response) :
+        print("Error occurred while deleting the multiple test results, please check for the correct result Ids and you have correct access for deleting the results")
+    else:
+        print("\nMultiple results has been deleted successfully")
+
+
+def create_and_delete_multiple_results() -> None:
+
+    # create multiple test results
+    print("\nCreating multiple test results.\nResult Ids are listed down below")    
+    result_ids = create_multiple_results()    
+    print("\nMultiple test results has been created successfully")
+
+    # Delete multiple test results
+    print("Please enter to delete these results")
+    input()
+    delete_multiple_results(result_ids)
 
 @click.command()
 @click.option("--server", help = "Enter server url")
@@ -59,47 +124,24 @@ def main(server, api_key):
     To run the example against a SystemLink Enterprise, the URL should include
     the scheme, host, and port if not default.\n
     For example:\n
-    python create_results_and_steps.py --server https://myserver:9091 api_key.\n
+    python delete_results.py --server https://myserver:9091 api_key.\n
 
     For more information on how to generate API key, please refer to the documentation provided.
     """
     test_data_manager_client.set_base_url_and_api_key(server, api_key)
-    
+
     try:
+        # Creating single test result and deleting it
+        create_and_delete_single_result()
 
-        test_result = get_test_result()
-
-        # create test result
-        response = test_data_manager_client.create_results(results=[test_result])
-        test_result = response["results"][0]
-        
-        print(f"The test result has been created under part number={test_result['partNumber']} with Id = {test_result['id']}")
-        print("Press enter to delete the result")
-        input()
-
-        # delete test result
-        test_data_manager_client.delete_result(test_result['id'], True)
-        print(f"\nThe test result with Id = {test_result['id']} has been deleted")
-        
-        # create multiple test results
-        print("\nCreating multiple test results.\nResult Ids are listed down below")
-        result_ids = []
-        
-        result_ids = create_multiple_results(result_ids, test_result)
-        
-        print("\nMultiple test results has been created successfully")
-        print("Please enter to delete these results")
-        input()
-
-        # Delete multiple test results
-        test_data_manager_client.delete_results(result_ids, True)
-        print("\nResults has been deleted successfully")
+        # Creating multiple test result and deleting them all at once
+        create_and_delete_multiple_results()        
         
     except Exception as e:
         print(e)
         print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the server is up and the URL or API key is valid")
         print("For more information on how to generate API key, please refer to the documentation provided.")
-        print("Try 'create_results_and_steps.py --help' for help.")
+        print("Try 'delete_results.py --help' for help.")
 
 if __name__ == "__main__":
     main()

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -13,8 +13,8 @@ def get_test_result():
     test_result = {
         "programName": "Power Test",
         "status": {
-            "statusType": "RUNNING",
-            "statusName": "Running"
+            "statusType": "PASSED",
+            "statusName": "Passed"
         },
         "systemId": None,
         "hostName": None,
@@ -24,7 +24,7 @@ def get_test_result():
         "partNumber": "NI-ABC-123-PWR1",
         "fileIds":None,
         "startedAt": str(datetime.datetime.now()),
-        "totalTimeInSeconds": 0.0
+        "totalTimeInSeconds": 13.6
     }
 
     return test_result

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -49,7 +49,7 @@ def main():
         response = test_data_manager_client.create_results(results=[test_result])
         test_result = response["results"][0]
         
-        print(f"The test result has been under part number={test_result['partNumber']} with Id = {test_result['id']}")
+        print(f"The test result has been created under part number={test_result['partNumber']} with Id = {test_result['id']}")
         print("Press enter to delete the result")
         input()
 
@@ -58,12 +58,12 @@ def main():
         print(f"\nThe test result with Id = {test_result['id']} has been deleted")
         
         # create multiple test results
-        print("\nCreating multiple test results.\nResult Ids has been listed down below")
+        print("\nCreating multiple test results.\nResult Ids are listed down below")
         result_ids = []
         
         result_ids = create_multiple_results(result_ids, test_result)
         
-        print("\nThe multiple results has been created successfully")
+        print("\nMultiple test results has been created successfully")
         print("Please enter to delete these results")
         input()
 

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -133,7 +133,7 @@ def update_steps(steps: List) -> Dict:
 
     return request_response.json()
 
-def delete_result(result_id: str, delete_steps: bool = True):
+def delete_result(result_id: str, delete_steps: bool = True) -> None:
     """
     Deletes the existing test result.
     :param result_id: result id which needs to be deleted
@@ -141,9 +141,9 @@ def delete_result(result_id: str, delete_steps: bool = True):
     if result_id == None :
         raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
     request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
-    request_response = raise_delete_request(request_uri)
+    raise_delete_request(request_uri)
 
-def delete_results(result_ids: List, delete_steps: bool = True):
+def delete_results(result_ids: List, delete_steps: bool = True) -> Dict:
     """
     Deletes the existing test results.
     :param result_ids: result ids which needs to be deleted
@@ -153,6 +153,10 @@ def delete_results(result_ids: List, delete_steps: bool = True):
     request_uri = f"{base_uri}{delete_results_route}"
     body = delete_results_request(result_ids, delete_steps)   
     request_response = raise_post_request(request_uri, body)
+    if request_response.status_code != 204 :
+        return request_response.json()
+    else:
+        return {}
 
 def raise_post_request(uri: str, body: Dict) -> requests.Response:
     """

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -143,6 +143,27 @@ def update_steps(steps):
 
     return request_response.json()
 
+def delete_result(result_id, delete_steps = True):
+    """
+    Deletes the existing test result.
+    :param result_id: result id which needs to be deleted
+    """
+    if result_id == None :
+        raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
+    request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
+    request_response = raise_delete_request(request_uri)
+
+def delete_results(result_ids, delete_steps = True):
+    """
+    Deletes the existing test results.
+    :param result_ids: result ids which needs to be deleted
+    """
+    if len(result_ids) == 0 or result_ids == None:
+        raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
+    request_uri = f"{base_uri}{delete_results_route}"
+    body = delete_results_request(result_ids, delete_steps)   
+    request_response = raise_post_request(request_uri, body)
+
 def raise_post_request(uri, body):
     """
     Makes the post request API call.
@@ -155,19 +176,13 @@ def raise_post_request(uri, body):
 
     return request_response
 
-def delete_result(result_id, delete_steps = True):
-    if result_id == None :
-        raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
-    request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
-    request_response = requests.delete(request_uri, headers=headers)
-
+def raise_delete_request(uri):
+    """
+    Makes the delete request API call.
+    :param uri: request uri which needs to be called
+    :return: json response of the api call
+    """
+    request_response = requests.delete(uri, headers=headers)
     request_response.raise_for_status()
 
-def delete_results(result_ids, delete_steps = True):
-    if len(result_ids) == 0 or result_ids == None:
-        raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
-    request_uri = f"{base_uri}{delete_results_route}"
-    body = delete_results_request(result_ids, delete_steps)   
-    request_response =  requests.post(request_uri, json=body, headers=headers)
-    
-    request_response.raise_for_status()
+    return request_response

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -156,16 +156,18 @@ def raise_post_request(uri, body):
     return request_response
 
 def delete_result(result_id, delete_steps = True):
+    if result_id == None :
+        raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
     request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
     request_response = requests.delete(request_uri, headers=headers)
 
     request_response.raise_for_status()
 
-def delete_results(result_ids, delete_steps = True):    
+def delete_results(result_ids, delete_steps = True):
+    if len(result_ids) == 0 or result_ids == None:
+        raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
     request_uri = f"{base_uri}{delete_results_route}"
     body = delete_results_request(result_ids, delete_steps)   
     request_response =  requests.post(request_uri, json=body, headers=headers)
     
     request_response.raise_for_status()
-
-

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -5,6 +5,8 @@ create_results_route = "nitestmonitor/v2/results"
 create_steps_route = "nitestmonitor/v2/steps"
 update_results_route = "nitestmonitor/v2/update-results"
 update_steps_route = "nitestmonitor/v2/update-steps"
+delete_results_route = "nitestmonitor/v2/delete-results"
+delete_result_route = "nitestmonitor/v2/results"
 
 def print_usage_and_exit(error:str):
     print("This example requires a configuration.")
@@ -66,6 +68,20 @@ def update_test_results_request(results: dict, determine_status_from_steps: bool
         "results": results,
         "determineStatusFromSteps": determine_status_from_steps
     }
+
+def delete_results_request(result_ids, delete_steps):
+    """
+    creates a delete test results request object
+    dictionary required for deleting the existing test results.
+    :param result_ids: List of result Ids that needs to be deleted
+    :param delete_steps: A boolean representing whether to delete steps associated with results or not
+    :return: A dictionary which is required for deleting the results
+    """
+    return {
+        "ids":result_ids,
+        "deleteSteps":delete_steps
+    }
+    pass
 
 def create_results(results):
     """
@@ -138,3 +154,18 @@ def raise_post_request(uri, body):
     request_response.raise_for_status()
 
     return request_response
+
+def delete_result(result_id, delete_steps = True):
+    request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
+    request_response = requests.delete(request_uri, headers=headers)
+
+    request_response.raise_for_status()
+
+def delete_results(result_ids, delete_steps = True):    
+    request_uri = f"{base_uri}{delete_results_route}"
+    body = delete_results_request(result_ids, delete_steps)   
+    request_response =  requests.post(request_uri, json=body, headers=headers)
+    
+    request_response.raise_for_status()
+
+

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -60,7 +60,7 @@ def update_test_results_request(results: List, determine_status_from_steps: bool
         "determineStatusFromSteps": determine_status_from_steps
     }
 
-def delete_results_request(result_ids, delete_steps):
+def delete_results_request(result_ids: List, delete_steps: bool):
     """
     creates a delete test results request object
     :param result_ids: List of result Ids that needs to be deleted
@@ -73,7 +73,7 @@ def delete_results_request(result_ids, delete_steps):
     }
     pass
 
-def create_results(results):
+def create_results(results: List) -> Dict:
     """
     Creates new test results from the supplied models. The server automatically generates the result ids.
     :param results: Results which needs to be created
@@ -133,7 +133,7 @@ def update_steps(steps: List) -> Dict:
 
     return request_response.json()
 
-def delete_result(result_id, delete_steps = True):
+def delete_result(result_id: str, delete_steps: bool = True):
     """
     Deletes the existing test result.
     :param result_id: result id which needs to be deleted
@@ -143,7 +143,7 @@ def delete_result(result_id, delete_steps = True):
     request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
     request_response = raise_delete_request(request_uri)
 
-def delete_results(result_ids, delete_steps = True):
+def delete_results(result_ids: List, delete_steps: bool = True):
     """
     Deletes the existing test results.
     :param result_ids: result ids which needs to be deleted
@@ -154,7 +154,7 @@ def delete_results(result_ids, delete_steps = True):
     body = delete_results_request(result_ids, delete_steps)   
     request_response = raise_post_request(request_uri, body)
 
-def raise_post_request(uri, body):
+def raise_post_request(uri: str, body: Dict) -> requests.Response:
     """
     Makes the post request API call.
     :param uri: request uri which needs to be called
@@ -166,7 +166,7 @@ def raise_post_request(uri, body):
 
     return request_response
 
-def raise_delete_request(uri):
+def raise_delete_request(uri: str) -> requests.Response:
     """
     Makes the delete request API call.
     :param uri: request uri which needs to be called

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -72,7 +72,6 @@ def update_test_results_request(results: dict, determine_status_from_steps: bool
 def delete_results_request(result_ids, delete_steps):
     """
     creates a delete test results request object
-    dictionary required for deleting the existing test results.
     :param result_ids: List of result Ids that needs to be deleted
     :param delete_steps: A boolean representing whether to delete steps associated with results or not
     :return: A dictionary which is required for deleting the results


### PR DESCRIPTION
**Justification**
In order to represent how to use the APIs created in the TestMonitor service in the SystemLink Enterprise version, there is a need to create examples that will show how to call the APIs, and what details are sent in the API request body.

**Implementation**
In this example, I have demonstrated how to use the Delete Result API and Delete Results API in Python

**Testing**
Manual testing completed