### PR TITLE
Added the Python Example for the Delete Results API Only

### DIFF
--- a/Python Examples/ReadMe.md
+++ b/Python Examples/ReadMe.md
@@ -1,0 +1,33 @@
+SystemLink Enterprise API Examples
+==============================
+
+This directory holds self-contained python scripts for the
+SystemLink Enterprise APIs. 
+
+Running an Example
+------------------
+
+Unless otherwise specified by the example's README, each example is run in the
+same way:
+
+1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
+2. Install the [Python SDK](https://www.python.org/downloads/) version 3.8 or higher.
+
+To run the example, use the following command:
+
+```
+python <filename.py> --server <url> <api_key>
+```
+
+For example: `python create_results_and_steps.py --server https://my_server apiKey`.
+
+How to generate API key
+-----------------------
+Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key
+
+API Examples
+------------
+### [Test Monitor](TestMonitor)
+
+- [CreateResultsAndSteps](TestMonitor/CreateResultsAndSteps/create_results_and_steps.py): Demonstrates how to use the SystemLink Test Monitor API to publish test results to the server.
+- [DeleteResults](TestMonitor/DeleteResults/delete_results.py): Demonstrates how to use the SystemLink Test Monitor API to create and delete test results.

--- a/Python Examples/ReadMe.md
+++ b/Python Examples/ReadMe.md
@@ -4,7 +4,7 @@ SystemLink Enterprise API Examples
 This directory holds self-contained python scripts for the
 SystemLink Enterprise APIs. 
 
-how to run the example?
+How to run the example?
 -----------------------
 
 Unless otherwise specified by the example's README, each example is run in the

--- a/Python Examples/ReadMe.md
+++ b/Python Examples/ReadMe.md
@@ -4,25 +4,25 @@ SystemLink Enterprise API Examples
 This directory holds self-contained python scripts for the
 SystemLink Enterprise APIs. 
 
-Running an Example
-------------------
+how to run the example?
+-----------------------
 
 Unless otherwise specified by the example's README, each example is run in the
 same way:
 
 1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
 2. Install the [Python SDK](https://www.python.org/downloads/) version 3.8 or higher.
+3. Install all the libraries mentioned in the [requirements.txt](/requirements.txt) by running `pip install requirements.txt` in command prompt.
+4. To run the example, use the following command:
 
-To run the example, use the following command:
+    ```
+    python <filename.py> --server <url> <api_key>
+    ```
 
-```
-python <filename.py> --server <url> <api_key>
-```
+    For example: `python create_results_and_steps.py --server https://my_server apiKey`.
 
-For example: `python create_results_and_steps.py --server https://my_server apiKey`.
-
-How to generate API key
------------------------
+How to generate API key?
+------------------------
 Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key
 
 API Examples

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -1,0 +1,28 @@
+Test Monitor Delete Results Example
+=================
+
+This is an python example demonstrating how to use the
+SystemLink Enterprise Test Monitor API to create and delete test results.
+
+Running the Example
+-------------------
+
+1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
+2. Install the [Python SDK](https://www.python.org/downloads/).
+
+To run the example, use the following command:
+
+```
+python <filename.py> --server <server_url> <api_key>
+```
+
+For example: `python delete_results.py --server https://my_server apiKey`.
+
+How to generate API key
+-----------------------
+Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key
+
+About the Example
+-----------------
+
+This example creates a single test result and deletes this created result by using Delete result Api and creates multiple(five) test results and deletes all these multiple results at a time by using delete-results POST Api.

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -1,28 +1,29 @@
 Test Monitor Delete Results Example
 =================
 
-This is an python example demonstrating how to use the
+This is a python example demonstrating how to use the
 SystemLink Enterprise Test Monitor API to create and delete test results.
 
-Running the Example
--------------------
+How to run the example?
+-----------------------
 
 1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
 2. Install the [Python SDK](https://www.python.org/downloads/).
+3. To run the example, use the following command:
 
-To run the example, use the following command:
+    ```
+    python <filename.py> --server <server_url> <api_key>
+    ```
 
-```
-python <filename.py> --server <server_url> <api_key>
-```
+    For example: `python delete_results.py --server https://my_server apiKey`.
 
-For example: `python delete_results.py --server https://my_server apiKey`.
+How to generate API key?
+------------------------
+Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key.
 
-How to generate API key
------------------------
-Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-enterprise/page/creating-an-api-key.html) for generating the API key
-
-About the Example
+About the example
 -----------------
 
-This example creates a single test result and deletes this created result by using Delete result Api and creates multiple(five) test results and deletes all these multiple results at a time by using delete-results POST Api.
+This example has two sections.
+The example in the first section creates a single test result and 
+deletes the created result by using delete-result API.The example in the second section creates multiple(five) test results and deletes all the created results at once using the delete-results API.

--- a/Python Examples/TestMonitor/DeleteResults/ReadMe.md
+++ b/Python Examples/TestMonitor/DeleteResults/ReadMe.md
@@ -2,14 +2,15 @@ Test Monitor Delete Results Example
 =================
 
 This is a python example demonstrating how to use the
-SystemLink Enterprise Test Monitor API to create and delete test results.
+SystemLink Enterprise Test Monitor APIs to create and delete test results.
 
 How to run the example?
 -----------------------
 
 1. Clone _or_ download and extract the [repository source](https://github.com/ni/systemlink-enterprise-examples/archive/master.zip).
 2. Install the [Python SDK](https://www.python.org/downloads/).
-3. To run the example, use the following command:
+3. Install all the libraries mentioned in the [requirements.txt](../requirements.txt) by running `pip install requirements.txt` in command prompt.
+4. To run the example, use the following command:
 
     ```
     python <filename.py> --server <server_url> <api_key>
@@ -24,6 +25,4 @@ Please refer to this [link](https://www.ni.com/docs/en-US/bundle/systemlink-ente
 About the example
 -----------------
 
-This example has two sections.
-The example in the first section creates a single test result and 
-deletes the created result by using delete-result API.The example in the second section creates multiple(five) test results and deletes all the created results at once using the delete-results API.
+This example has two sections. The example in the first section creates a single test result and deletes the created result by using delete-result API. The example in the second section creates multiple(five) test results and deletes all the created results at once using the delete-results API.

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -1,10 +1,11 @@
 """
 SystemLink Enterprise TestMonitor delete results example
 
-This example creates a single test result and 
-deletes this created result by using delete result API and 
-creates multiple(five) test results and 
-deletes all these multiple results at once by using delete-results API.
+This example has two sections.
+The example in the first section creates a single test result and 
+deletes the created result by using delete result API.
+The example in the second section creates multiple(five) test results and 
+deletes all the created results at once using the delete-results API.
 """
 
 import uuid
@@ -51,7 +52,7 @@ def create_single_result() -> Dict:
     # create test result
     response = test_data_manager_client.create_results(results=[test_result])
     if is_partial_success_response(response):
-        raise Exception("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+        raise Exception("Error occurred while creating a new test result. Please check if you have provided the correct test result details and if you have the right access for creating the new test result.")
     test_result = response["results"][0]
 
     return test_result
@@ -60,9 +61,9 @@ def create_single_result() -> Dict:
 def delete_single_result(result_id: str) -> None:
     try:
         test_data_manager_client.delete_result(result_id, True)
-        print(f"\nThe test result with Id = {result_id} has been deleted")
+        print(f"\nThe test result with Id = {result_id} has been deleted successfully")
     except:
-        print("Error occurred while deleting the test result, please check for the correct result Id and you have correct access for deleting the results")
+        print("Error occurred while deleting the test result. Please check if you have provided the correct result Id and if you have the right access for deleting the test result.")
 
 
 def create_and_delete_single_result() -> None:
@@ -86,7 +87,7 @@ def create_multiple_results() -> List:
         test_result["programName"] = program_name + str(i)
         response = test_data_manager_client.create_results(results=[test_result])
         if is_partial_success_response(response):
-            print("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+            print("Error occurred while creating a new test result. Please check if you have provided the correct test result details and if you have the right access for creating the new test results")
         else:
             test_result = response["results"][0]
             result_ids.append(test_result["id"])
@@ -94,41 +95,42 @@ def create_multiple_results() -> List:
     if len(result_ids) > 0 :
         return result_ids
     else:
-        raise Exception("Error occurred while creating multiple new test results, please check whether you have correct access for creating the new test results")
+        raise Exception("Error occurred while creating multiple new test results. Please check if you have the right access for creating test results.")
 
 
 def delete_multiple_results(result_ids: List) -> None:
     response = test_data_manager_client.delete_results(result_ids, True)
     if is_partial_success_response(response) :
-        print("Error occurred while deleting the multiple test results, please check for the correct result Ids and you have correct access for deleting the results")
+        print("Error occurred while deleting the test results. Please check if you have provided the correct result Ids and if you have the right access for deleting the test results.")
     else:
-        print("\nMultiple results has been deleted successfully")
+        print("\nMultiple test results have been deleted successfully.")
 
 
 def create_and_delete_multiple_results() -> None:
 
     # create multiple test results
-    print("\nCreating multiple test results.\nResult Ids are listed down below")    
+    print("\nCreating multiple test results.\nResult Ids are listed below:")    
     result_ids = create_multiple_results()    
-    print("\nMultiple test results has been created successfully")
+    print("\nMultiple test results have been created successfully.")
 
     # Delete multiple test results
-    print("Please enter to delete these results")
+    print("Press enter to delete these results.")
     input()
     delete_multiple_results(result_ids)
 
 @click.command()
-@click.option("--server", help = "Enter server url")
+@click.option("--server", help = "Enter server URL.")
 @click.argument("api_key")
 def main(server, api_key):
     """
-    To run the example against a SystemLink Enterprise, the URL should include
-    the scheme, host, and port if not default.\n
+    To run the example against SystemLink Enterprise, the URL should include
+    the scheme, host, and port if not already available by default.\n
     For example:\n
     python delete_results.py --server https://myserver:9091 api_key.\n
 
     For more information on how to generate API key, please refer to the documentation provided.
     """
+
     test_data_manager_client.set_base_url_and_api_key(server, api_key)
 
     try:
@@ -140,9 +142,9 @@ def main(server, api_key):
         
     except Exception as e:
         print(e)
-        print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the server is up and the URL or API key is valid")
+        print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the following: server is up, correct URL and API key.")
         print("For more information on how to generate API key, please refer to the documentation provided.")
-        print("Try 'delete_results.py --help' for help.")
+        print("Try running the 'delete_results.py --help' command for help.")
 
 if __name__ == "__main__":
     main()

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -80,9 +80,10 @@ def create_and_delete_single_result() -> None:
 
 def create_multiple_results() -> List:
     test_result = get_test_result()
+    program_name = test_result["programName"]
     result_ids = []
     for i in range(0,5):
-        test_result['programName'] = test_result['programName'] + str(i)
+        test_result["programName"] = program_name + str(i)
         response = test_data_manager_client.create_results(results=[test_result])
         if is_partial_success_response(response):
             print("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -61,9 +61,9 @@ def create_single_result() -> Dict:
 def delete_single_result(result_id: str) -> None:
     try:
         test_data_manager_client.delete_result(result_id, True)
-        print(f"\nThe test result with Id = {result_id} has been deleted successfully")
+        print(f"\nThe test result with ID = {result_id} has been deleted successfully")
     except:
-        print("Error occurred while deleting the test result. Please check if you have provided the correct result Id and if you have the right access for deleting the test result.")
+        print("Error occurred while deleting the test result. Please check if you have provided the correct result ID and if you have the right access for deleting the test result.")
 
 
 def create_and_delete_single_result() -> None:
@@ -71,7 +71,7 @@ def create_and_delete_single_result() -> None:
     # create test result
     print("Creating New test result")
     test_result = create_single_result()    
-    print(f"Test result has been created under part number={test_result['partNumber']} with Id = {test_result['id']}")
+    print(f"Test result has been created under part number={test_result['partNumber']} with ID = {test_result['id']}")
     
     # delete test result
     print("Press enter to delete the result")
@@ -101,7 +101,7 @@ def create_multiple_results() -> List:
 def delete_multiple_results(result_ids: List) -> None:
     response = test_data_manager_client.delete_results(result_ids, True)
     if is_partial_success_response(response) :
-        print("Error occurred while deleting the test results. Please check if you have provided the correct result Ids and if you have the right access for deleting the test results.")
+        print("Error occurred while deleting the test results. Please check if you have provided the correct result IDs and if you have the right access for deleting the test results.")
     else:
         print("\nMultiple test results have been deleted successfully.")
 
@@ -109,7 +109,7 @@ def delete_multiple_results(result_ids: List) -> None:
 def create_and_delete_multiple_results() -> None:
 
     # create multiple test results
-    print("\nCreating multiple test results.\nResult Ids are listed below:")    
+    print("\nCreating multiple test results.\nResult IDs are listed below:")    
     result_ids = create_multiple_results()    
     print("\nMultiple test results have been created successfully.")
 
@@ -124,7 +124,7 @@ def create_and_delete_multiple_results() -> None:
 def main(server, api_key):
     """
     To run the example against SystemLink Enterprise, the URL should include
-    the scheme, host, and port if not already available by default.\n
+    the scheme, host, and port if not default.\n
     For example:\n
     python delete_results.py --server https://myserver:9091 api_key.\n
 

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -21,33 +21,19 @@ sys.path.append(parent)
 
 import test_data_manager_client
 
-def get_test_result() -> Dict:
-    test_result = {
-        "programName": "Power Test",
-        "status": {
-            "statusType": "RUNNING",
-            "statusName": "Running"
-        },
-        "systemId": None,
-        "hostName": None,
-        "properties":None,
-        "serialNumber": str(uuid.uuid4()),
-        "operator": "John Smith",
-        "partNumber": "NI-ABC-123-PWR1",
-        "fileIds":None,
-        "startedAt": str(datetime.datetime.utcnow()),
-        "totalTimeInSeconds": 0.0
-    }
-
-    return test_result
-
 
 def is_partial_success_response(response: Dict) -> bool:
     return "error" in response.keys()
 
 
 def create_single_result() -> Dict:
-    test_result = get_test_result()
+    test_result = test_data_manager_client.create_test_result(
+        program_name = "Power Test", 
+        part_number = "NI-ABC-123-PWR", 
+        operator = "John Smith", 
+        serial_number = str(uuid.uuid4()), 
+        started_at = str(datetime.datetime.utcnow())
+    )
 
     # create test result
     response = test_data_manager_client.create_results(results=[test_result])
@@ -80,7 +66,13 @@ def create_and_delete_single_result() -> None:
 
 
 def create_multiple_results() -> List:
-    test_result = get_test_result()
+    test_result = test_data_manager_client.create_test_result(
+        program_name = "Power Test", 
+        part_number = "NI-ABC-123-PWR", 
+        operator = "John Smith", 
+        serial_number = str(uuid.uuid4()), 
+        started_at = str(datetime.datetime.utcnow())
+    )
     program_name = test_result["programName"]
     result_ids = []
     for i in range(0,5):

--- a/Python Examples/TestMonitor/DeleteResults/delete_results.py
+++ b/Python Examples/TestMonitor/DeleteResults/delete_results.py
@@ -1,0 +1,147 @@
+"""
+SystemLink Enterprise TestMonitor delete results example
+
+This example creates a single test result and 
+deletes this created result by using delete result API and 
+creates multiple(five) test results and 
+deletes all these multiple results at once by using delete-results API.
+"""
+
+import uuid
+import sys
+import os
+import datetime
+from typing import Dict, List
+import click
+
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+import test_data_manager_client
+
+def get_test_result() -> Dict:
+    test_result = {
+        "programName": "Power Test",
+        "status": {
+            "statusType": "RUNNING",
+            "statusName": "Running"
+        },
+        "systemId": None,
+        "hostName": None,
+        "properties":None,
+        "serialNumber": str(uuid.uuid4()),
+        "operator": "John Smith",
+        "partNumber": "NI-ABC-123-PWR1",
+        "fileIds":None,
+        "startedAt": str(datetime.datetime.utcnow()),
+        "totalTimeInSeconds": 0.0
+    }
+
+    return test_result
+
+
+def is_partial_success_response(response: Dict) -> bool:
+    return "error" in response.keys()
+
+
+def create_single_result() -> Dict:
+    test_result = get_test_result()
+
+    # create test result
+    response = test_data_manager_client.create_results(results=[test_result])
+    if is_partial_success_response(response):
+        raise Exception("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+    test_result = response["results"][0]
+
+    return test_result
+
+
+def delete_single_result(result_id: str) -> None:
+    try:
+        test_data_manager_client.delete_result(result_id, True)
+        print(f"\nThe test result with Id = {result_id} has been deleted")
+    except:
+        print("Error occurred while deleting the test result, please check for the correct result Id and you have correct access for deleting the results")
+
+
+def create_and_delete_single_result() -> None:
+    
+    # create test result
+    print("Creating New test result")
+    test_result = create_single_result()    
+    print(f"Test result has been created under part number={test_result['partNumber']} with Id = {test_result['id']}")
+    
+    # delete test result
+    print("Press enter to delete the result")
+    input()
+    delete_single_result(test_result["id"])
+
+
+def create_multiple_results() -> List:
+    test_result = get_test_result()
+    result_ids = []
+    for i in range(0,5):
+        test_result['programName'] = test_result['programName'] + str(i)
+        response = test_data_manager_client.create_results(results=[test_result])
+        if is_partial_success_response(response):
+            print("Error occurred while creating new test result, please check for correct test result details and have correct access for creating the new test results")
+        else:
+            test_result = response["results"][0]
+            result_ids.append(test_result["id"])
+            print(f"{test_result['id']}")
+    if len(result_ids) > 0 :
+        return result_ids
+    else:
+        raise Exception("Error occurred while creating multiple new test results, please check whether you have correct access for creating the new test results")
+
+
+def delete_multiple_results(result_ids: List) -> None:
+    response = test_data_manager_client.delete_results(result_ids, True)
+    if is_partial_success_response(response) :
+        print("Error occurred while deleting the multiple test results, please check for the correct result Ids and you have correct access for deleting the results")
+    else:
+        print("\nMultiple results has been deleted successfully")
+
+
+def create_and_delete_multiple_results() -> None:
+
+    # create multiple test results
+    print("\nCreating multiple test results.\nResult Ids are listed down below")    
+    result_ids = create_multiple_results()    
+    print("\nMultiple test results has been created successfully")
+
+    # Delete multiple test results
+    print("Please enter to delete these results")
+    input()
+    delete_multiple_results(result_ids)
+
+@click.command()
+@click.option("--server", help = "Enter server url")
+@click.argument("api_key")
+def main(server, api_key):
+    """
+    To run the example against a SystemLink Enterprise, the URL should include
+    the scheme, host, and port if not default.\n
+    For example:\n
+    python delete_results.py --server https://myserver:9091 api_key.\n
+
+    For more information on how to generate API key, please refer to the documentation provided.
+    """
+    test_data_manager_client.set_base_url_and_api_key(server, api_key)
+
+    try:
+        # Creating single test result and deleting it
+        create_and_delete_single_result()
+
+        # Creating multiple test result and deleting them all at once
+        create_and_delete_multiple_results()        
+        
+    except Exception as e:
+        print(e)
+        print("The given URL or API key might be invalid or the server might be down. Please try again after verifying the server is up and the URL or API key is valid")
+        print("For more information on how to generate API key, please refer to the documentation provided.")
+        print("Try 'delete_results.py --help' for help.")
+
+if __name__ == "__main__":
+    main()

--- a/Python Examples/TestMonitor/requirements.txt
+++ b/Python Examples/TestMonitor/requirements.txt
@@ -1,0 +1,7 @@
+certifi==2022.12.7
+charset-normalizer==3.1.0
+idna==3.4
+requests==2.28.2
+urllib3==1.26.14
+colorama==0.4.6
+click==8.1.3

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -1,6 +1,8 @@
-import sys
+import random
+import uuid
+import datetime
 import requests
-from typing import Any, Tuple, Dict, List
+from typing import Dict, List
 
 create_results_route = "nitestmonitor/v2/results"
 create_steps_route = "nitestmonitor/v2/steps"
@@ -24,6 +26,99 @@ def set_base_url_and_api_key(server_url: str, key: str) -> None:
     api_key = key
     update_headers()
 
+def create_test_result(
+        program_name: str = "Power Test", 
+        part_number: str = "NI-ABC-123-PWR",
+        operator: str = None, 
+        serial_number: str = str(uuid.uuid4()), 
+        started_at: str = str(datetime.datetime.utcnow()), 
+        system_id: str = None,
+        host_name: str = None,
+        properties: Dict = None,
+        file_ids: List = None,
+        status: Dict = None
+    ) -> Dict:
+    """
+    Creates the result data and
+    populates it to match the TestStand data model.
+    :param program_name: The test result's program name.
+    :param part_number: The test results's part number.
+    :param operator: The test result's operator.
+    :param serial_number: The test results's serial number.
+    :param started_at: The test result's start time.
+    :param system_id: The test result's system id.
+    :param host_name: The test result's host_name.
+    :param properties: The test result's properties.
+    :param file_ids: The test result's file id.
+    :param status: The test result's status
+    :return: The result data used to create a test result.
+    """
+    result_status = status if status else {
+        "statusType": "RUNNING",
+        "statusName": "Running"
+        }
+
+    test_result = {
+        "programName": program_name,
+        "status": result_status,
+        "systemId": system_id,
+        "hostName": host_name,
+        "properties":properties,
+        "serialNumber": serial_number,
+        "operator": operator,
+        "partNumber": part_number,
+        "fileIds":file_ids,
+        "startedAt": started_at,
+        "totalTimeInSeconds": random.uniform(0, 1) * 10
+    }
+
+    return test_result
+
+def create_test_step(
+    name: str,
+    step_type: str,
+    result_id:str,
+    parent_id: str = None,
+    children: List = None,
+    inputs: List[Dict] = None,
+    outputs: List[Dict] = None,
+    parameters: Dict = None,
+    status: Dict = None,
+) -> Dict:
+    """
+    Creates the step data and
+    populates it to match the TestStand data model.
+    :param name: The test step's name.
+    :param step_type: The test step's type.
+    :param inputs: The test step's input values.
+    :param outputs: The test step's output values.
+    :param parameters: The measurement parameters.
+    :param status: The test step's status
+    :return: The step data used to create a test step.
+    """
+    step_status = status if status else {
+        "statusType": "RUNNING",
+        "statusName": "Running"
+        }
+
+    step_data = {
+        "stepId": None,
+        "parentId": parent_id,
+        "resultId": result_id,
+        "children": children,
+        "data": parameters,
+        "dataModel": "TestStand",
+        "name": name,
+        "startedAt":  str(datetime.datetime.utcnow()),
+        "status": step_status,
+        "stepType": step_type,
+        "totalTimeInSeconds": random.uniform(0, 1) * 10,
+        "inputs": inputs,
+        "outputs": outputs
+    }
+
+    return step_data
+
 def create_test_result_request(results: List) -> Dict:
     """
     Creates a create test result request object.
@@ -34,7 +129,7 @@ def create_test_result_request(results: List) -> Dict:
         "results":results
     }
 
-def test_step_create_or_update_request_object(steps: List, update_result_total_time: bool = True) -> Dict:
+def test_step_create_or_update_request_object(steps: List, update_result_total_time: bool = False) -> Dict:
     """
     Creates a create/update test step request object.
     :param results: List of steps to be created/updated
@@ -46,7 +141,7 @@ def test_step_create_or_update_request_object(steps: List, update_result_total_t
         "updateResultTotalTime": update_result_total_time
     }
 
-def update_test_results_request(results: List, determine_status_from_steps: bool = True) -> Dict:
+def update_test_results_request(results: List, determine_status_from_steps: bool = False) -> Dict:
     """
     Creates a update test result request object.
     :param results: List of results to be updated
@@ -93,7 +188,7 @@ def update_results(results: List) -> Dict:
     """
     if len(results) == 0 :
         raise ValueError("Number of results to be updated can not be empty.")
-    body = update_test_results_request(results, determine_status_from_steps=True)
+    body = update_test_results_request(results, determine_status_from_steps = True)
     request_url = base_url + update_results_route
     request_response = raise_post_request(request_url, body)
 
@@ -110,8 +205,8 @@ def create_steps(steps: List) -> Dict:
     if len(steps) == 0 :
         raise ValueError("Number of steps to be created can not be empty.")
     body = test_step_create_or_update_request_object(
-            steps, update_result_total_time=True
-        )
+        steps, update_result_total_time = True
+    )
     request_url = base_url + create_steps_route
     request_response = raise_post_request(request_url, body)
 
@@ -126,8 +221,8 @@ def update_steps(steps: List) -> Dict:
     if len(steps) == 0 :
         raise ValueError("Number of steps to be updated can not be empty.")
     body = test_step_create_or_update_request_object(
-                steps, update_result_total_time=True
-            )
+        steps, update_result_total_time = True
+    )
     request_url = base_url + update_steps_route
     request_response = raise_post_request(request_url, body)
 

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -62,7 +62,7 @@ def update_test_results_request(results: List, determine_status_from_steps: bool
 def delete_results_request(result_ids: List, delete_steps: bool):
     """
     Creates a delete test results request object.
-    :param result_ids: List of result Ids to be deleted
+    :param result_ids: List of result IDs to be deleted
     :param delete_steps: A boolean to determine if the steps associated with results should be deleted or not
     :return: A dictionary which is required for deleting the results
     """
@@ -73,7 +73,7 @@ def delete_results_request(result_ids: List, delete_steps: bool):
 
 def create_results(results: List) -> Dict:
     """
-    Creates new test results from the supplied models. The server automatically generates the result ids.
+    Creates new test results from the supplied models. The server automatically generates the result IDs.
     :param results: List of results to be created
     :return: json response after creating the results
     """
@@ -103,7 +103,7 @@ def create_steps(steps: List) -> Dict:
     """
     Creates new test steps from the supplied models. 
     The result associated with the steps must exist prior to step creation. 
-    The server automatically generates step ids if not provided.
+    The server automatically generates step IDs if not provided.
     :param steps: Steps to be created
     :return: json response after creating steps
     """
@@ -136,7 +136,7 @@ def update_steps(steps: List) -> Dict:
 def delete_result(result_id: str, delete_steps: bool = True) -> None:
     """
     Deletes test result.
-    :param result_id: result Id to be deleted
+    :param result_id: result ID to be deleted
     """
     if result_id == None :
         raise ValueError("Missing required parameter 'result_id' in ResultsApi->DeleteResultV2 request.")
@@ -146,7 +146,7 @@ def delete_result(result_id: str, delete_steps: bool = True) -> None:
 def delete_results(result_ids: List, delete_steps: bool = True) -> Dict:
     """
     Delete multiple test results.
-    :param result_ids: List of result Ids to be deleted
+    :param result_ids: List of result IDs to be deleted
     :return: json response after deleting the results
     """
     if result_ids == None or len(result_ids) == 0:

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -148,7 +148,7 @@ def delete_results(result_ids: List, delete_steps: bool = True) -> Dict:
     Deletes the existing test results.
     :param result_ids: result ids which needs to be deleted
     """
-    if len(result_ids) == 0 or result_ids == None:
+    if result_ids == None or len(result_ids) == 0:
         raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
     request_uri = f"{base_uri}{delete_results_route}"
     body = delete_results_request(result_ids, delete_steps)   

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -10,7 +10,7 @@ delete_results_route = "nitestmonitor/v2/delete-results"
 delete_result_route = "nitestmonitor/v2/results"
 
 api_key = ""
-base_uri = ""
+base_url = ""
 
 headers = { 'X-NI-API-KEY': api_key }
 
@@ -18,16 +18,16 @@ def update_headers() -> None:
     global headers, api_key
     headers = { 'X-NI-API-KEY': api_key }
 
-def set_base_url_and_api_key(server_uri: str, key: str) -> None:
-    global api_key, base_uri
-    base_uri = server_uri
+def set_base_url_and_api_key(server_url: str, key: str) -> None:
+    global api_key, base_url
+    base_url = server_url
     api_key = key
     update_headers()
 
 def create_test_result_request(results: List) -> Dict:
     """
     Creates a create test result request object.
-    :param results: List of results that needs to be created
+    :param results: List of results to be created
     :return: A dictionary which is required for creating the results
     """
     return {
@@ -37,9 +37,8 @@ def create_test_result_request(results: List) -> Dict:
 def test_step_create_or_update_request_object(steps: List, update_result_total_time: bool = True) -> Dict:
     """
     Creates a create/update test step request object.
-    :param results: List of steps that needs to be created/updated
-    :param update_result_total_time: A boolean to state 
-    whether to update result total time or not
+    :param results: List of steps to be created/updated
+    :param update_result_total_time: A boolean to determine if result total time needs to be updated
     :return: A dictionary which is required for creating/updating the steps
     """
     return{
@@ -50,9 +49,9 @@ def test_step_create_or_update_request_object(steps: List, update_result_total_t
 def update_test_results_request(results: List, determine_status_from_steps: bool = True) -> Dict:
     """
     Creates a update test result request object.
-    :param results: List of results that needs to be updated
-    :param determine_status_from_steps: A boolean representing 
-    whether the status of result should be updated based on result or not
+    :param results: List of results to be updated
+    :param determine_status_from_steps: A boolean to determine if the result status needs to be updated 
+    based on the status of the steps
     :return: A dictionary which is required for updating the results
     """
     return{
@@ -62,121 +61,123 @@ def update_test_results_request(results: List, determine_status_from_steps: bool
 
 def delete_results_request(result_ids: List, delete_steps: bool):
     """
-    creates a delete test results request object
-    :param result_ids: List of result Ids that needs to be deleted
-    :param delete_steps: A boolean representing whether to delete steps associated with results or not
+    Creates a delete test results request object.
+    :param result_ids: List of result Ids to be deleted
+    :param delete_steps: A boolean to determine if the steps associated with results should be deleted or not
     :return: A dictionary which is required for deleting the results
     """
     return {
         "ids":result_ids,
         "deleteSteps":delete_steps
     }
-    pass
 
 def create_results(results: List) -> Dict:
     """
     Creates new test results from the supplied models. The server automatically generates the result ids.
-    :param results: Results which needs to be created
+    :param results: List of results to be created
     :return: json response after creating the results
     """
     if len(results) == 0 :
-        raise ValueError("Number of results needs to be created can not be empty")
+        raise ValueError("Number of results to be created can not be empty.")
     body = create_test_result_request(results)
-    request_uri = base_uri + create_results_route
-    request_response = raise_post_request(request_uri, body)
+    request_url = base_url + create_results_route
+    request_response = raise_post_request(request_url, body)
 
     return request_response.json()
 
 def update_results(results: List) -> Dict:
     """
     Updates existing test results by merging or replacing values.
-    :param results: Results which needs to be updated
+    :param results: List of results to be updated
     :return: json response after updating the results
     """
     if len(results) == 0 :
-        raise ValueError("Number of results needs to be updated can not be empty")
+        raise ValueError("Number of results to be updated can not be empty.")
     body = update_test_results_request(results, determine_status_from_steps=True)
-    request_uri = base_uri + update_results_route
-    request_response = raise_post_request(request_uri, body)
+    request_url = base_url + update_results_route
+    request_response = raise_post_request(request_url, body)
 
     return request_response.json()
 
 def create_steps(steps: List) -> Dict:
     """
-    Creates new test steps from the supplied models. The result associated with the step must exist prior to step creation. The server automatically generates step ids if not supplied.
-    :param steps: Steps which needs to be created
+    Creates new test steps from the supplied models. 
+    The result associated with the steps must exist prior to step creation. 
+    The server automatically generates step ids if not provided.
+    :param steps: Steps to be created
     :return: json response after creating steps
     """
     if len(steps) == 0 :
-        raise ValueError("Number of steps needs to be created can not be empty")
+        raise ValueError("Number of steps to be created can not be empty.")
     body = test_step_create_or_update_request_object(
             steps, update_result_total_time=True
         )
-    request_uri = base_uri + create_steps_route
-    request_response = raise_post_request(request_uri, body)
+    request_url = base_url + create_steps_route
+    request_response = raise_post_request(request_url, body)
 
     return request_response.json()
 
 def update_steps(steps: List) -> Dict:
     """
     Updates existing steps by merging or replacing values.
-    :param steps: Steps which needs to be updated
-    :return: json response after updating the steps
+    :param steps: List of steps to be updated
+    :return: json response after updating steps
     """
     if len(steps) == 0 :
-        raise ValueError("Number of steps needs to be updated can not be empty")
+        raise ValueError("Number of steps to be updated can not be empty.")
     body = test_step_create_or_update_request_object(
                 steps, update_result_total_time=True
             )
-    request_uri = base_uri + update_steps_route
-    request_response = raise_post_request(request_uri, body)
+    request_url = base_url + update_steps_route
+    request_response = raise_post_request(request_url, body)
 
     return request_response.json()
 
 def delete_result(result_id: str, delete_steps: bool = True) -> None:
     """
-    Deletes the existing test result.
-    :param result_id: result id which needs to be deleted
+    Deletes test result.
+    :param result_id: result Id to be deleted
     """
     if result_id == None :
-        raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
-    request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
-    raise_delete_request(request_uri)
+        raise ValueError("Missing required parameter 'result_id' in ResultsApi->DeleteResultV2 request.")
+    request_url = f"{base_url}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
+    raise_delete_request(request_url)
 
 def delete_results(result_ids: List, delete_steps: bool = True) -> Dict:
     """
-    Deletes the existing test results.
-    :param result_ids: result ids which needs to be deleted
+    Delete multiple test results.
+    :param result_ids: List of result Ids to be deleted
+    :return: json response after deleting the results
     """
     if result_ids == None or len(result_ids) == 0:
-        raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
-    request_uri = f"{base_uri}{delete_results_route}"
+        raise ValueError("result_ids is a required property for ResultsApi->DeleteResultsV2 and cannot be null or empty.")
+    request_url = f"{base_url}{delete_results_route}"
     body = delete_results_request(result_ids, delete_steps)   
-    request_response = raise_post_request(request_uri, body)
+    request_response = raise_post_request(request_url, body)
     if request_response.status_code != 204 :
         return request_response.json()
     else:
         return {}
 
-def raise_post_request(uri: str, body: Dict) -> requests.Response:
+def raise_post_request(url: str, body: Dict) -> requests.Response:
     """
     Makes the post request API call.
-    :param uri: request uri which needs to be called
+    :param url: request url to be called
     :param body: API call body
-    :return: response of the api call
+    :return: response of the API call
     """
-    request_response =  requests.post(uri, json=body, headers=headers)
+    request_response =  requests.post(url, json=body, headers=headers)
     request_response.raise_for_status()
 
     return request_response
 
-def raise_delete_request(uri: str) -> requests.Response:
+def raise_delete_request(url: str) -> requests.Response:
     """
     Makes the delete request API call.
-    :param uri: request uri which needs to be called
-    :return: json response of the api call
+    :param url: request url to be called
+    :return: response of the API call
     """
-    request_response = requests.delete(uri, headers=headers)
+    request_response = requests.delete(url, headers=headers)
     request_response.raise_for_status()
 
     return request_response

--- a/Python Examples/TestMonitor/test_data_manager_client.py
+++ b/Python Examples/TestMonitor/test_data_manager_client.py
@@ -1,0 +1,182 @@
+import sys
+import requests
+from typing import Any, Tuple, Dict, List
+
+create_results_route = "nitestmonitor/v2/results"
+create_steps_route = "nitestmonitor/v2/steps"
+update_results_route = "nitestmonitor/v2/update-results"
+update_steps_route = "nitestmonitor/v2/update-steps"
+delete_results_route = "nitestmonitor/v2/delete-results"
+delete_result_route = "nitestmonitor/v2/results"
+
+api_key = ""
+base_uri = ""
+
+headers = { 'X-NI-API-KEY': api_key }
+
+def update_headers() -> None:
+    global headers, api_key
+    headers = { 'X-NI-API-KEY': api_key }
+
+def set_base_url_and_api_key(server_uri: str, key: str) -> None:
+    global api_key, base_uri
+    base_uri = server_uri
+    api_key = key
+    update_headers()
+
+def create_test_result_request(results: List) -> Dict:
+    """
+    Creates a create test result request object.
+    :param results: List of results that needs to be created
+    :return: A dictionary which is required for creating the results
+    """
+    return {
+        "results":results
+    }
+
+def test_step_create_or_update_request_object(steps: List, update_result_total_time: bool = True) -> Dict:
+    """
+    Creates a create/update test step request object.
+    :param results: List of steps that needs to be created/updated
+    :param update_result_total_time: A boolean to state 
+    whether to update result total time or not
+    :return: A dictionary which is required for creating/updating the steps
+    """
+    return{
+        "steps": steps,
+        "updateResultTotalTime": update_result_total_time
+    }
+
+def update_test_results_request(results: List, determine_status_from_steps: bool = True) -> Dict:
+    """
+    Creates a update test result request object.
+    :param results: List of results that needs to be updated
+    :param determine_status_from_steps: A boolean representing 
+    whether the status of result should be updated based on result or not
+    :return: A dictionary which is required for updating the results
+    """
+    return{
+        "results": results,
+        "determineStatusFromSteps": determine_status_from_steps
+    }
+
+def delete_results_request(result_ids: List, delete_steps: bool):
+    """
+    creates a delete test results request object
+    :param result_ids: List of result Ids that needs to be deleted
+    :param delete_steps: A boolean representing whether to delete steps associated with results or not
+    :return: A dictionary which is required for deleting the results
+    """
+    return {
+        "ids":result_ids,
+        "deleteSteps":delete_steps
+    }
+    pass
+
+def create_results(results: List) -> Dict:
+    """
+    Creates new test results from the supplied models. The server automatically generates the result ids.
+    :param results: Results which needs to be created
+    :return: json response after creating the results
+    """
+    if len(results) == 0 :
+        raise ValueError("Number of results needs to be created can not be empty")
+    body = create_test_result_request(results)
+    request_uri = base_uri + create_results_route
+    request_response = raise_post_request(request_uri, body)
+
+    return request_response.json()
+
+def update_results(results: List) -> Dict:
+    """
+    Updates existing test results by merging or replacing values.
+    :param results: Results which needs to be updated
+    :return: json response after updating the results
+    """
+    if len(results) == 0 :
+        raise ValueError("Number of results needs to be updated can not be empty")
+    body = update_test_results_request(results, determine_status_from_steps=True)
+    request_uri = base_uri + update_results_route
+    request_response = raise_post_request(request_uri, body)
+
+    return request_response.json()
+
+def create_steps(steps: List) -> Dict:
+    """
+    Creates new test steps from the supplied models. The result associated with the step must exist prior to step creation. The server automatically generates step ids if not supplied.
+    :param steps: Steps which needs to be created
+    :return: json response after creating steps
+    """
+    if len(steps) == 0 :
+        raise ValueError("Number of steps needs to be created can not be empty")
+    body = test_step_create_or_update_request_object(
+            steps, update_result_total_time=True
+        )
+    request_uri = base_uri + create_steps_route
+    request_response = raise_post_request(request_uri, body)
+
+    return request_response.json()
+
+def update_steps(steps: List) -> Dict:
+    """
+    Updates existing steps by merging or replacing values.
+    :param steps: Steps which needs to be updated
+    :return: json response after updating the steps
+    """
+    if len(steps) == 0 :
+        raise ValueError("Number of steps needs to be updated can not be empty")
+    body = test_step_create_or_update_request_object(
+                steps, update_result_total_time=True
+            )
+    request_uri = base_uri + update_steps_route
+    request_response = raise_post_request(request_uri, body)
+
+    return request_response.json()
+
+def delete_result(result_id: str, delete_steps: bool = True) -> None:
+    """
+    Deletes the existing test result.
+    :param result_id: result id which needs to be deleted
+    """
+    if result_id == None :
+        raise ValueError("Missing required parameter 'result_id' when calling ResultsApi->DeleteResultV2")
+    request_uri = f"{base_uri}{delete_result_route}/{result_id}?deleteSteps{delete_steps}"
+    raise_delete_request(request_uri)
+
+def delete_results(result_ids: List, delete_steps: bool = True) -> Dict:
+    """
+    Deletes the existing test results.
+    :param result_ids: result ids which needs to be deleted
+    """
+    if len(result_ids) == 0 or result_ids == None:
+        raise ValueError("result_ids is a required property for DeleteResultsRequest and cannot be null or empty")
+    request_uri = f"{base_uri}{delete_results_route}"
+    body = delete_results_request(result_ids, delete_steps)   
+    request_response = raise_post_request(request_uri, body)
+    if request_response.status_code != 204 :
+        return request_response.json()
+    else:
+        return {}
+
+def raise_post_request(uri: str, body: Dict) -> requests.Response:
+    """
+    Makes the post request API call.
+    :param uri: request uri which needs to be called
+    :param body: API call body
+    :return: response of the api call
+    """
+    request_response =  requests.post(uri, json=body, headers=headers)
+    request_response.raise_for_status()
+
+    return request_response
+
+def raise_delete_request(uri: str) -> requests.Response:
+    """
+    Makes the delete request API call.
+    :param uri: request uri which needs to be called
+    :return: json response of the api call
+    """
+    request_response = requests.delete(uri, headers=headers)
+    request_response.raise_for_status()
+
+    return request_response


### PR DESCRIPTION
**Justification**
In order to represent how to use the APIs created in the TestMonitor service in the SystemLink Enterprise version, there is a need to create examples that will show how to call the APIs, and what details are sent in the API request body.

**Implementation**
In this example, I have demonstrated how to use the Delete Result API and Delete Results API in Python

**Testing**
Manual testing completed